### PR TITLE
[WIP] Add an url option to toggleNavigation request.

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -38,11 +38,11 @@ var AjaxRequest =
 			if (parent.hasClass('node-collapsed')) {
 				item.setStyle('display', null);
 				parent.removeClass('node-collapsed').addClass('node-expanded');
-				new Request.Contao().post({'action':'toggleNavigation', 'id':id, 'state':1, 'REQUEST_TOKEN':Contao.request_token});
+				new Request.Contao({'url': el.href}).post({'action':'toggleNavigation', 'id':id, 'state':1, 'REQUEST_TOKEN':Contao.request_token});
 			} else {
 				item.setStyle('display', 'none');
 				parent.removeClass('node-expanded').addClass('node-collapsed');
-				new Request.Contao().post({'action':'toggleNavigation', 'id':id, 'state':0, 'REQUEST_TOKEN':Contao.request_token});
+				new Request.Contao({'url': el.href}).post({'action':'toggleNavigation', 'id':id, 'state':0, 'REQUEST_TOKEN':Contao.request_token});
 			}
 			return false;
 		}


### PR DESCRIPTION
This way we can specify the url to which the request will be sent, which allows
us to create a route for toggling the navigation instead of doing it in `\BackendUser`.

See: https://github.com/sheeep/core-bundle/issues/1
Cc: @discordier